### PR TITLE
Fix ConfigMaps Errors and Add pod_logs of Raw Data

### DIFF
--- a/src/spaceone/inventory/libs/manager.py
+++ b/src/spaceone/inventory/libs/manager.py
@@ -329,6 +329,8 @@ class KubernetesManager(BaseManager):
 
     def get_config_data_keys(self, config_data):
         keys = ""
+        if config_data is None:
+            return keys
         for k in config_data.keys():
             keys = k + "," + keys
         return keys

--- a/src/spaceone/inventory/manager/config/custom_resource_definition_manager.py
+++ b/src/spaceone/inventory/manager/config/custom_resource_definition_manager.py
@@ -49,7 +49,7 @@ class CustomResourceDefinitionManager(KubernetesManager):
             self.connector_name, **params
         )
         list_all_crd = crd_conn.list_custom_resource_definition()
-        _LOGGER.debug(f"list_all_crd => {list_all_crd}")
+        # _LOGGER.debug(f"list_all_crd => {list_all_crd}")
 
         for crd in list_all_crd:
             try:

--- a/src/spaceone/inventory/manager/workload/pod_manager.py
+++ b/src/spaceone/inventory/manager/workload/pod_manager.py
@@ -77,6 +77,7 @@ class PodManager(KubernetesManager):
                     raw_data.get("status", {}).get("container_statuses", []),
                     raw_data.get("spec", {}).get("containers", []),
                 )
+                raw_data["pod_logs"] = self._get_pod_logs(raw_data.get("metadata", {}))
 
                 labels = raw_data["metadata"]["labels"]
 
@@ -127,3 +128,12 @@ class PodManager(KubernetesManager):
         else:
             restarts = 0
         return restarts
+
+    @staticmethod
+    def _get_pod_logs(metadata):
+        pod_logs = {}
+        if metadata:
+            pod_logs["name"] = metadata.get("name", "")
+            pod_logs["namespace"] = metadata.get("namespace", "")
+
+        return pod_logs

--- a/src/spaceone/inventory/model/workload/pod/data.py
+++ b/src/spaceone/inventory/model/workload/pod/data.py
@@ -85,6 +85,11 @@ class PodStatus(Model):
     start_time = DateTimeType(serialize_when_none=False)
 
 
+class PodLogs(Model):
+    name = StringType(serialize_when_none=False)
+    namespace = StringType(serialize_when_none=False)
+
+
 class Pod(Model):
     api_version = StringType(serialize_when_none=False)
     uid = StringType(serialize_when_none=False)
@@ -95,7 +100,7 @@ class Pod(Model):
     restarts = IntType(serialize_when_none=False)
     age = StringType(serialize_when_none=False)
     containers = StringType(serialize_when_none=False)
-    pod_logs = ModelType(ObjectMeta, serialize_when_none=False)
+    pod_logs = ModelType(PodLogs, serialize_when_none=False)
 
     def reference(self):
         return {"resource_id": self.uid, "external_link": f""}

--- a/src/spaceone/inventory/model/workload/pod/data.py
+++ b/src/spaceone/inventory/model/workload/pod/data.py
@@ -95,6 +95,7 @@ class Pod(Model):
     restarts = IntType(serialize_when_none=False)
     age = StringType(serialize_when_none=False)
     containers = StringType(serialize_when_none=False)
+    pod_logs = ModelType(ObjectMeta, serialize_when_none=False)
 
     def reference(self):
         return {"resource_id": self.uid, "external_link": f""}


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
- [Bug fix] I found that codes work in most cases, but if I service especially **Istio**, it could not get any `config_data`.
- [Refactor] Also, add pod_logs in data of Raw Data.

### Known issue
- [Bug fix] There was an issue such as calling `keys()` from NoneType data.
- [Refactor] For developing a logging feature, need the pod_logs key in Raw Data.